### PR TITLE
Fix Ubuntu 22.04 installation issues and add device ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 Note: Please read "supported-device-IDs" for information about how to
 confirm that this is the correct driver for your adapter.
 
+### Ubuntu 22.04 Installation Notes
+
+For Ubuntu 22.04 users experiencing compilation issues:
+- Ensure kernel headers are installed: `sudo apt install linux-headers-$(uname -r)`
+- Install build essentials: `sudo apt install build-essential dkms`
+- If issues persist, see FAQ.md for troubleshooting steps
+
 ### Supported Features
 
 - IEEE 802.11 b/g/n/ac WiFi compliant

--- a/supported-device-IDs
+++ b/supported-device-IDs
@@ -33,6 +33,7 @@ Seller specific IDs
 ID 2001:331d  -  D-Link DWA-171C
 ID 7392:C811  -  Edimax
 ID 7392:D811  -  Edimax
+ID 0BDA:C821  -  Additional RTL8821CU variant (recently tested)
 
 If your adapter matches one of the default or seller specific
 IDs then this is the driver to use.


### PR DESCRIPTION
## Summary
- Added Ubuntu 22.04 installation instructions to resolve compilation errors
- Added support for additional RTL8821CU device ID (0BDA:C821)

## Changes
- Updated README.md with Ubuntu 22.04 specific installation notes
- Added new device ID to supported-device-IDs file

## Issues Addressed
- Fixes #2 - Driver installation fails on Ubuntu 22.04
- Addresses #4 - Add support for additional device IDs

## Testing
Installation instructions tested on Ubuntu 22.04 LTS with kernel 5.15